### PR TITLE
Fix issue with zrangebyscore

### DIFF
--- a/src/main/java/com/sematext/solr/redis/command/ZRangeByScore.java
+++ b/src/main/java/com/sematext/solr/redis/command/ZRangeByScore.java
@@ -16,6 +16,6 @@ public class ZRangeByScore implements Command {
 
     log.debug("Fetching ZRANGEBYSCORE from Redis for key: {} ({}, {})", key, min, max);
 
-    return Command.ResultUtil.tupleIteratorToMap(jedis.zrangeByScoreWithScores(key, max, min));
+    return Command.ResultUtil.tupleIteratorToMap(jedis.zrangeByScoreWithScores(key, min, max));
   }
 }

--- a/src/test/java/com/sematext/solr/redis/TestRedisQParser.java
+++ b/src/test/java/com/sematext/solr/redis/TestRedisQParser.java
@@ -1080,7 +1080,7 @@ public class TestRedisQParser {
     when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, jedisPoolMock);
     Query query = redisQParser.parse();
-    verify(jedisMock).zrangeByScoreWithScores("simpleKey", "+inf", "-inf");
+    verify(jedisMock).zrangeByScoreWithScores("simpleKey", "-inf", "+inf");
     Set<Term> terms = new HashSet<>();
     query.extractTerms(terms);
     Assert.assertEquals(2, terms.size());
@@ -1100,7 +1100,7 @@ public class TestRedisQParser {
     when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, jedisPoolMock);
     Query query = redisQParser.parse();
-    verify(jedisMock).zrangeByScoreWithScores("simpleKey", "100", "1");
+    verify(jedisMock).zrangeByScoreWithScores("simpleKey", "1", "100");
     Set<Term> terms = new HashSet<>();
     query.extractTerms(terms);
     Assert.assertEquals(2, terms.size());


### PR DESCRIPTION
Parameters are inverted. Can we apply and release 1.2.1?
