### PR TITLE
Add support for JSON deserialization and gzip compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 /target/
+
+# IDE
+/.idea/
+solr-redis.iml
+
+# Maven
+/dependency-reduced-pom.xml

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Configure the query parser plugin in `solrconfig.xml`. Add the following to the 
  * **operator** - Operator which connects terms taken from Redis. Allowed values are AND/OR (optional - default is OR)
  * **useAnalyzer** - Turns on and off query time analyzer true/false (optional - default is true)
 
+GET specific parameters:
+ * **compression**: Defines a format for compression. `gzip` is the only supported option right now
+ * **serialization**: Defines an format for deserialization. `json` is the only supported option right now and assumes to unpack the JSON payload as a list of strings
+
 SRANDMEMBER specific parameters:
  * **count** - Number of random keys to retrieve (default `1`)
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <solr.version>4.9.0</solr.version>
         <junit.version>4.11</junit.version>
+        <gson.version>2.3.1</gson.version>
         <mockito.version>1.9.5</mockito.version>
 
         <skip.unit.tests>false</skip.unit.tests>
@@ -116,6 +117,12 @@
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-core</artifactId>
             <version>${solr.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
         </dependency>
 
         <dependency>
@@ -232,6 +239,7 @@
                                     <include>redis.clients:*</include>
                                     <include>com.google.guava</include>
                                     <include>org.apache.commons</include>
+                                    <include>com.google.code.gson</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/src/main/java/com/sematext/solr/redis/RedisQParser.java
+++ b/src/main/java/com/sematext/solr/redis/RedisQParser.java
@@ -19,6 +19,7 @@ import com.sematext.solr.redis.command.SMembers;
 import com.sematext.solr.redis.command.SRandMember;
 import com.sematext.solr.redis.command.SUnion;
 import com.sematext.solr.redis.command.Sort;
+import com.sematext.solr.redis.command.ValueFilter;
 import com.sematext.solr.redis.command.ZRange;
 import com.sematext.solr.redis.command.ZRangeByScore;
 import com.sematext.solr.redis.command.ZRevRange;
@@ -83,7 +84,7 @@ final class RedisQParser extends QParser {
     commands.put("LRANGE", new LRange());
     commands.put("LINDEX", new LIndex());
 
-    commands.put("GET", new Get());
+    commands.put("GET", new Get(new ValueFilter()));
     commands.put("MGET", new MGet());
     commands.put("KEYS", new Keys());
 

--- a/src/main/java/com/sematext/solr/redis/command/DeserializationException.java
+++ b/src/main/java/com/sematext/solr/redis/command/DeserializationException.java
@@ -1,0 +1,22 @@
+package com.sematext.solr.redis.command;
+
+public class DeserializationException extends Exception {
+  private static final long serialVersionUID = -5231842833274667633L;
+
+  public DeserializationException(final String message) {
+    super(message);
+  }
+
+  public DeserializationException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  public DeserializationException(final Throwable cause) {
+    super(cause);
+  }
+
+  protected DeserializationException(final String message, final Throwable cause,
+                                     final boolean enableSuppression, final boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+}

--- a/src/main/java/com/sematext/solr/redis/command/Get.java
+++ b/src/main/java/com/sematext/solr/redis/command/Get.java
@@ -3,19 +3,36 @@ package com.sematext.solr.redis.command;
 import org.apache.solr.common.params.SolrParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import redis.clients.jedis.JedisCommands;
-import java.util.Arrays;
+import redis.clients.jedis.BinaryJedisCommands;
 import java.util.Map;
 
-public final class Get implements Command<JedisCommands> {
+public final class Get implements Command<BinaryJedisCommands> {
   private static final Logger log = LoggerFactory.getLogger(Get.class);
+  private final ValueFilter valueFilter;
+
+  public Get(final ValueFilter valueFilter) {
+    this.valueFilter = valueFilter;
+  }
 
   @Override
-  public Map<String, Float> execute(final JedisCommands client, final SolrParams params) {
+  public Map<String, Float> execute(final BinaryJedisCommands client, final SolrParams params) {
     final String key = ParamUtil.assertGetStringByName(params, "key");
+    final byte[] byteValue = client.get(key.getBytes());
+
+    if (byteValue == null) {
+      return null;
+    }
 
     log.debug("Fetching GET from Redis for key: {}", key);
 
-    return ResultUtil.stringIteratorToMap(Arrays.asList(client.get(key)));
+    try {
+      return valueFilter.filterValue(params, byteValue);
+    } catch (final UnsupportedAlgorithmException e) {
+      log.error(e.getMessage());
+      return null;
+    } catch (final DeserializationException e) {
+      log.error(e.getMessage());
+      return null;
+    }
   }
 }

--- a/src/main/java/com/sematext/solr/redis/command/HGet.java
+++ b/src/main/java/com/sematext/solr/redis/command/HGet.java
@@ -4,7 +4,7 @@ import org.apache.solr.common.params.SolrParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.JedisCommands;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 
 public final class HGet implements Command<JedisCommands> {
@@ -17,6 +17,6 @@ public final class HGet implements Command<JedisCommands> {
 
     log.debug("Fetching HGET from Redis for key: {} ({})", key, field);
 
-    return ResultUtil.stringIteratorToMap(Arrays.asList(client.hget(key, field)));
+    return ResultUtil.stringIteratorToMap(Collections.singletonList(client.hget(key, field)));
   }
 }

--- a/src/main/java/com/sematext/solr/redis/command/LIndex.java
+++ b/src/main/java/com/sematext/solr/redis/command/LIndex.java
@@ -4,7 +4,7 @@ import org.apache.solr.common.params.SolrParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.JedisCommands;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 
 public final class LIndex implements Command<JedisCommands> {
@@ -17,6 +17,6 @@ public final class LIndex implements Command<JedisCommands> {
 
     log.debug("Fetching LINDEX from Redis for key: {} ({})", key, index);
 
-    return ResultUtil.stringIteratorToMap(Arrays.asList(client.lindex(key, index)));
+    return ResultUtil.stringIteratorToMap(Collections.singletonList(client.lindex(key, index)));
   }
 }

--- a/src/main/java/com/sematext/solr/redis/command/ScriptingCommand.java
+++ b/src/main/java/com/sematext/solr/redis/command/ScriptingCommand.java
@@ -3,6 +3,7 @@ package com.sematext.solr.redis.command;
 import org.apache.solr.common.params.SolrParams;
 import redis.clients.jedis.ScriptingCommands;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -41,7 +42,7 @@ abstract class ScriptingCommand implements Command<ScriptingCommands> {
   }
 
   private Map<String, Float> returnScalar(final Object result) {
-    return ResultUtil.stringIteratorToMap(Arrays.asList(result.toString()));
+    return ResultUtil.stringIteratorToMap(Collections.singletonList(result.toString()));
   }
 
   private Map<String, Float> returnList(final Iterable<String> result) {

--- a/src/main/java/com/sematext/solr/redis/command/UnsupportedAlgorithmException.java
+++ b/src/main/java/com/sematext/solr/redis/command/UnsupportedAlgorithmException.java
@@ -1,0 +1,22 @@
+package com.sematext.solr.redis.command;
+
+public class UnsupportedAlgorithmException extends Exception {
+  private static final long serialVersionUID = -8875629362503003369L;
+
+  public UnsupportedAlgorithmException(final String message) {
+    super(message);
+  }
+
+  public UnsupportedAlgorithmException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  public UnsupportedAlgorithmException(final Throwable cause) {
+    super(cause);
+  }
+
+  protected UnsupportedAlgorithmException(final String message, final Throwable cause,
+    final boolean enableSuppression, final boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+}

--- a/src/main/java/com/sematext/solr/redis/command/ValueFilter.java
+++ b/src/main/java/com/sematext/solr/redis/command/ValueFilter.java
@@ -20,14 +20,14 @@ public class ValueFilter {
     final String compression = ParamUtil.tryGetStringByName(params, "compression", "");
     final String serializationForm = ParamUtil.tryGetStringByName(params, "serialization", "");
 
-    return deserialize(serializationForm, decompress(compression, byteValue));
+    return deserialize(serializationForm, inflate(compression, byteValue));
   }
 
-  private static String decompress(final String compression, final byte[] bytes) throws UnsupportedAlgorithmException {
+  private static String inflate(final String compression, final byte[] bytes) throws UnsupportedAlgorithmException {
     if ("".equals(compression)) {
       return new String(bytes);
     } else if ("gzip".equals(compression)) {
-      return decompressGzip(bytes);
+      return inflateGzip(bytes);
     } else {
       throw new UnsupportedAlgorithmException(String.format("Unsupported algorithm: '%s'", compression));
     }
@@ -45,7 +45,7 @@ public class ValueFilter {
     }
   }
 
-  private static String decompressGzip(final byte[] bytes) {
+  private static String inflateGzip(final byte[] bytes) {
     log.debug("Decompressing GZIP data");
 
     try {

--- a/src/main/java/com/sematext/solr/redis/command/ValueFilter.java
+++ b/src/main/java/com/sematext/solr/redis/command/ValueFilter.java
@@ -1,0 +1,82 @@
+package com.sematext.solr.redis.command;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import org.apache.solr.common.params.SolrParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
+
+public class ValueFilter {
+  private static final Logger log = LoggerFactory.getLogger(ValueFilter.class);
+
+  Map<String, Float> filterValue(final SolrParams params, final byte[] byteValue)
+      throws UnsupportedAlgorithmException, DeserializationException {
+    final String compression = ParamUtil.tryGetStringByName(params, "compression", "");
+    final String serializationForm = ParamUtil.tryGetStringByName(params, "serialization", "");
+
+    return deserialize(serializationForm, decompress(compression, byteValue));
+  }
+
+  private static String decompress(final String compression, final byte[] bytes) throws UnsupportedAlgorithmException {
+    if ("".equals(compression)) {
+      return new String(bytes);
+    } else if ("gzip".equals(compression)) {
+      return decompressGzip(bytes);
+    } else {
+      throw new UnsupportedAlgorithmException(String.format("Unsupported algorithm: '%s'", compression));
+    }
+  }
+
+  private static Map<String, Float> deserialize(final String serializationFormat, final String value)
+      throws DeserializationException {
+
+    if ("".equals(serializationFormat)) {
+      return ResultUtil.stringIteratorToMap(Collections.singletonList(value));
+    } else if ("json".equals(serializationFormat)) {
+      return ResultUtil.stringIteratorToMap(Arrays.asList(deserializeJson(value)));
+    } else {
+      throw new DeserializationException(String.format("Unsupported serialization format: '%s'", serializationFormat));
+    }
+  }
+
+  private static String decompressGzip(final byte[] bytes) {
+    log.debug("Decompressing GZIP data");
+
+    try {
+      try (
+          final GZIPInputStream stream = new GZIPInputStream(new ByteArrayInputStream(bytes));
+          final BufferedReader buffer = new BufferedReader(new InputStreamReader(stream, "UTF-8"));
+      ) {
+        String value = "";
+        String line;
+        while ((line = buffer.readLine()) != null) {
+          value += line;
+        }
+        return value;
+      }
+    } catch (final UnsupportedEncodingException e) {
+      log.warn("Unsupported encoding, using string as is: {}", e.getMessage());
+      return new String(bytes);
+    } catch (final IOException e) {
+      log.warn("Compression exception, using string as is: {}", e.getMessage());
+      return new String(bytes);
+    }
+  }
+
+  private static String[] deserializeJson(final String value) {
+    log.debug("Deserialization JSON data");
+
+    try {
+      return new Gson().fromJson(value, String[].class);
+    } catch (final JsonSyntaxException e) {
+      log.warn("Deserialization error, using string as is: {}", e.getMessage());
+      return new String[]{value};
+    }
+  }
+}

--- a/src/test/java/com/sematext/solr/redis/command/ValueFilterTest.java
+++ b/src/test/java/com/sematext/solr/redis/command/ValueFilterTest.java
@@ -1,0 +1,32 @@
+package com.sematext.solr.redis.command;
+
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ValueFilterTest {
+  private ValueFilter valueFilter;
+
+  @Before
+  public void setUp() {
+    valueFilter = new ValueFilter();
+  }
+
+  @Test(expected = UnsupportedAlgorithmException.class)
+  public void shouldThrowExceptionOnUnsupportedCompressionAlgorithm()
+      throws DeserializationException, UnsupportedAlgorithmException {
+    final ModifiableSolrParams params = new ModifiableSolrParams();
+    params.set("compression", "unsupportedAlgorithm");
+
+    valueFilter.filterValue(params, new byte[]{});
+  }
+
+  @Test(expected = DeserializationException.class)
+  public void shouldThrowExceptionOnInvalidDeserializationAlgorithm()
+      throws DeserializationException, UnsupportedAlgorithmException {
+    final ModifiableSolrParams params = new ModifiableSolrParams();
+    params.set("serialization", "unsupported");
+
+    valueFilter.filterValue(params, new byte[]{});
+  }
+}


### PR DESCRIPTION
Adds support for JSON serialization and compression to allow storing large list of integers in a more space efficient way (see http://labs.octivi.com/how-we-cut-down-memory-usage-by-82/) as normal keys if no list operations are needed.