### PR TITLE
Change analyzer default to false

### DIFF
--- a/src/main/java/com/sematext/solr/redis/RedisQParser.java
+++ b/src/main/java/com/sematext/solr/redis/RedisQParser.java
@@ -145,7 +145,7 @@ final class RedisQParser extends QParser {
 
     operator = "AND".equalsIgnoreCase(operatorString) ? BooleanClause.Occur.MUST : BooleanClause.Occur.SHOULD;
 
-    useQueryTimeAnalyzer = localParams.getBool("useAnalyzer", true);
+    useQueryTimeAnalyzer = localParams.getBool("useAnalyzer", false);
   }
 
   @Override

--- a/src/test/java/com/sematext/solr/redis/TestRedisQParser.java
+++ b/src/test/java/com/sematext/solr/redis/TestRedisQParser.java
@@ -1276,7 +1276,7 @@ public class TestRedisQParser {
   public void shouldTurnAnalysisOn() throws SyntaxError {
     when(localParamsMock.get("command")).thenReturn("smembers");
     when(localParamsMock.get("key")).thenReturn("simpleKey");
-    when(localParamsMock.getBool("useAnalyzer", true)).thenReturn(true);
+    when(localParamsMock.getBool("useAnalyzer", false)).thenReturn(true);
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(requestMock.getSchema()).thenReturn(schema);
     when(schema.getQueryAnalyzer()).thenReturn(new WhitespaceAnalyzer(Version.LUCENE_48));
@@ -1293,7 +1293,7 @@ public class TestRedisQParser {
   public void shouldRetryWhenRedisFailed() throws SyntaxError {
     when(localParamsMock.get("command")).thenReturn("smembers");
     when(localParamsMock.get("key")).thenReturn("simpleKey");
-    when(localParamsMock.getBool("useAnalyzer", true)).thenReturn(false);
+    when(localParamsMock.getBool("useAnalyzer", false)).thenReturn(false);
     when(localParamsMock.get("retries")).thenReturn("2");
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(requestMock.getSchema()).thenReturn(schema);

--- a/src/test/java/com/sematext/solr/redis/TestRedisQParserPluginIT.java
+++ b/src/test/java/com/sematext/solr/redis/TestRedisQParserPluginIT.java
@@ -1050,29 +1050,33 @@ public class TestRedisQParserPluginIT extends SolrTestCaseJ4 {
   @Test
   public void shouldReturnSingleDocumentOnEvalWithInteger() {
     String hash;
-    final String[] doc = {"id", "1", "int_field", "100"};
-    assertU(adoc(doc));
+    final String[] doc1 = {"id", "1", "int_field", "100"};
+    final String[] doc2 = {"id", "2", "int_field", "200"};
+    final String[] doc3 = {"id", "2", "int_field", "300"};
+    assertU(adoc(doc1));
+    assertU(adoc(doc2));
+    assertU(adoc(doc3));
     assertU(commit());
 
     final ModifiableSolrParams params = new ModifiableSolrParams();
     params.set("q", "*:*");
 
-    params.set("fq", "{!redis command=eval script='return KEYS[1] + 0;' key=100}int_field");
+    params.set("fq", "{!redis command=eval script='return KEYS[1] + 0;' key=100 useAnalyzer=true}int_field");
     assertQ(req(params), "*[count(//doc)=1]", "//result/doc[1]/str[@name='id'][.='1']");
     hash = sha1("return KEYS[1] + 0;");
-    params.set("fq", "{!redis command=evalsha sha1=" + hash + " key=100}int_field");
+    params.set("fq", "{!redis command=evalsha sha1=" + hash + " key=100 useAnalyzer=true}int_field");
     assertQ(req(params), "*[count(//doc)=1]", "//result/doc[1]/str[@name='id'][.='1']");
 
-    params.set("fq", "{!redis command=eval script='return ARGV[1] + 0;' arg=100}int_field");
+    params.set("fq", "{!redis command=eval script='return ARGV[1] + 0;' arg=100 useAnalyzer=true}int_field");
     assertQ(req(params), "*[count(//doc)=1]", "//result/doc[1]/str[@name='id'][.='1']");
     hash = sha1("return ARGV[1] + 0;");
-    params.set("fq", "{!redis command=evalsha sha1=" + hash + " arg=100}int_field");
+    params.set("fq", "{!redis command=evalsha sha1=" + hash + " arg=100 useAnalyzer=true}int_field");
     assertQ(req(params), "*[count(//doc)=1]", "//result/doc[1]/str[@name='id'][.='1']");
 
-    params.set("fq", "{!redis command=eval script='return 100;'}int_field");
+    params.set("fq", "{!redis command=eval script='return 100;' useAnalyzer=true}int_field");
     assertQ(req(params), "*[count(//doc)=1]", "//result/doc[1]/str[@name='id'][.='1']");
     hash = sha1("return 100;");
-    params.set("fq", "{!redis command=evalsha sha1=" + hash + "}int_field");
+    params.set("fq", "{!redis command=evalsha sha1=" + hash + " useAnalyzer=true}int_field");
     assertQ(req(params), "*[count(//doc)=1]", "//result/doc[1]/str[@name='id'][.='1']");
   }
 
@@ -1086,22 +1090,22 @@ public class TestRedisQParserPluginIT extends SolrTestCaseJ4 {
     final ModifiableSolrParams params = new ModifiableSolrParams();
     params.set("q", "*:*");
 
-    params.set("fq", "{!redis command=eval script='return KEYS[1];' key=1.123}double_field");
+    params.set("fq", "{!redis command=eval script='return KEYS[1];' key=1.123 useAnalyzer=true}double_field");
     assertQ(req(params), "*[count(//doc)=1]", "//result/doc[1]/str[@name='id'][.='1']");
     hash = sha1("return KEYS[1];");
-    params.set("fq", "{!redis command=evalsha sha1=" + hash + " key=1.123}double_field");
+    params.set("fq", "{!redis command=evalsha sha1=" + hash + " key=1.123 useAnalyzer=true}double_field");
     assertQ(req(params), "*[count(//doc)=1]", "//result/doc[1]/str[@name='id'][.='1']");
 
-    params.set("fq", "{!redis command=eval script='return ARGV[1];' arg=1.123}double_field");
+    params.set("fq", "{!redis command=eval script='return ARGV[1];' arg=1.123 useAnalyzer=true}double_field");
     assertQ(req(params), "*[count(//doc)=1]", "//result/doc[1]/str[@name='id'][.='1']");
     hash = sha1("return ARGV[1];");
-    params.set("fq", "{!redis command=evalsha sha1=" + hash + " arg=1.123}double_field");
+    params.set("fq", "{!redis command=evalsha sha1=" + hash + " arg=1.123 useAnalyzer=true}double_field");
     assertQ(req(params), "*[count(//doc)=1]", "//result/doc[1]/str[@name='id'][.='1']");
 
-    params.set("fq", "{!redis command=eval script='return \\'1.123\\';'}double_field");
+    params.set("fq", "{!redis command=eval script='return \\'1.123\\';' useAnalyzer=true}double_field");
     assertQ(req(params), "*[count(//doc)=1]", "//result/doc[1]/str[@name='id'][.='1']");
     hash = sha1("return '1.123';");
-    params.set("fq", "{!redis command=evalsha sha1=" + hash + "}double_field");
+    params.set("fq", "{!redis command=evalsha sha1=" + hash + " useAnalyzer=true}double_field");
     assertQ(req(params), "*[count(//doc)=1]", "//result/doc[1]/str[@name='id'][.='1']");
   }
 


### PR DESCRIPTION
Change the default to false. I have no idea why the scripting tests start failing without the analyzer, @prog8 maybe you have a hint.