### PR TITLE
Update to solr 5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,10 +91,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <solr.version>4.9.0</solr.version>
-        <junit.version>4.11</junit.version>
+        <solr.version>5.3.0</solr.version>
+        <junit.version>4.12</junit.version>
         <gson.version>2.3.1</gson.version>
-        <mockito.version>1.9.5</mockito.version>
+        <mockito.version>1.10.19</mockito.version>
 
         <skip.unit.tests>false</skip.unit.tests>
         <skip.integration.tests>true</skip.integration.tests>

--- a/src/main/java/com/sematext/lucene/query/extractor/ConstantScoreQueryExtractor.java
+++ b/src/main/java/com/sematext/lucene/query/extractor/ConstantScoreQueryExtractor.java
@@ -3,6 +3,7 @@ package com.sematext.lucene.query.extractor;
 import java.util.List;
 import java.util.Set;
 import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
 
 /**
@@ -24,7 +25,7 @@ public class ConstantScoreQueryExtractor extends QueryExtractor<ConstantScoreQue
   @Override
   public void extract(final ConstantScoreQuery q, final Iterable<QueryExtractor<? extends Query>> extractors,
           final List<Query> extractedQueries) throws UnsupportedOperationException {
-    if (q.getQuery() != null) {
+    if (q.getQuery() != null && !(q.getQuery() instanceof Filter)) {
       extractQuery(q.getQuery(), extractors, extractedQueries);
     } else {
       extractedQueries.add(q);

--- a/src/main/java/com/sematext/solr/highlighter/TaggedQueryHighlighter.java
+++ b/src/main/java/com/sematext/solr/highlighter/TaggedQueryHighlighter.java
@@ -45,12 +45,6 @@ public class TaggedQueryHighlighter extends DefaultSolrHighlighter {
   private static final String MAIN_HIGHLIGHT = "##default##";
 
   /**
-   * TaggedQueryHighlighter.
-   */
-  public TaggedQueryHighlighter() {
-  }
-
-  /**
    * TaggedQueryHighlighter which takes solrCore as parameter. It is used to be compatible with
    * org.apache.solr.highlight.DefaultSolrHighlighter.
    *
@@ -66,7 +60,6 @@ public class TaggedQueryHighlighter extends DefaultSolrHighlighter {
       throws IOException {
 
     final Collection<TaggedQuery> taggedQueries = new ArrayList<>();
-    final List<Query> otherQueries = new ArrayList<>();
     try {
       final List<Query> extractedQueries = new ArrayList<>();
       QueryExtractor.extractQuery(query, extractedQueries);

--- a/src/test/java/com/sematext/lucene/query/extractor/TestConstantScoreQueryExtractor.java
+++ b/src/test/java/com/sematext/lucene/query/extractor/TestConstantScoreQueryExtractor.java
@@ -9,8 +9,11 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
 import org.junit.Test;
 import static org.mockito.Mockito.mock;
 
@@ -41,7 +44,7 @@ public class TestConstantScoreQueryExtractor extends TestQueryExtractor {
 
     constantScoreQueryExtractor.extract(constantScoreQuery, DEFAULT_EXTRACTORS, extractedQueries);
     assertEquals(1, extractedQueries.size());
-    assertTrue(extractedQueries.get(0) instanceof ConstantScoreQuery);
+    assertThat(extractedQueries.get(0), instanceOf(ConstantScoreQuery.class));
     assertEquals(constantScoreQuery, extractedQueries.get(0));
   }
 

--- a/src/test/java/com/sematext/solr/highlighter/TestTaggedQueryHighlighterIT.java
+++ b/src/test/java/com/sematext/solr/highlighter/TestTaggedQueryHighlighterIT.java
@@ -16,7 +16,7 @@ import redis.clients.jedis.Jedis;
  * @author prog
  */
 public class TestTaggedQueryHighlighterIT extends SolrTestCaseJ4 {
-  
+
   private Jedis jedis;
 
   @BeforeClass

--- a/src/test/java/com/sematext/solr/redis/TestRedisQParser.java
+++ b/src/test/java/com/sematext/solr/redis/TestRedisQParser.java
@@ -3,8 +3,8 @@ package com.sematext.solr.redis;
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.util.Version;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.schema.IndexSchema;
@@ -20,9 +20,7 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.SortingParams;
 import redis.clients.jedis.Tuple;
-import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisException;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.*;
@@ -95,13 +93,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.smembers(anyString())).thenReturn(new HashSet<>(Arrays.asList("123", "321")));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).smembers("simpleKey");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -111,13 +106,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.smembers(anyString())).thenReturn(new HashSet<String>());
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(0, redisQParser.parse());
     verify(jedisMock).smembers("simpleKey");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(0, terms.size());
   }
 
   @Test
@@ -137,13 +129,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.srandmember(anyString(), anyInt())).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).srandmember("simpleKey", 2);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -153,13 +142,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.srandmember(anyString(), anyInt())).thenReturn(Collections.singletonList("123"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(1, redisQParser.parse());
     verify(jedisMock).srandmember("simpleKey", 1);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(1, terms.size());
   }
 
   @Test
@@ -169,13 +155,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.srandmember(anyString(), anyInt())).thenReturn(new ArrayList<String>());
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(0, redisQParser.parse());
     verify(jedisMock).srandmember("simpleKey", 1);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(0, terms.size());
   }
 
   @Test
@@ -200,13 +183,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.sinter(anyString(), anyString())).thenReturn(new HashSet<>(Arrays.asList("123", "321")));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).sinter("key1", "key2");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -218,13 +198,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.sinter(anyString(), anyString())).thenReturn(new HashSet<String>());
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(0, redisQParser.parse());
     verify(jedisMock).sinter("key1", "key2");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(0, terms.size());
   }
 
   @Test
@@ -243,13 +220,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.keys(anyString())).thenReturn(new HashSet<>(Arrays.asList("123", "321")));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).keys("pattern");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -259,13 +233,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.sdiff(anyString(), anyString())).thenReturn(new HashSet<String>());
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(0, redisQParser.parse());
     verify(jedisMock).keys("pattern");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(0, terms.size());
   }
 
   @Test
@@ -290,13 +261,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.sdiff(anyString(), anyString())).thenReturn(new HashSet<>(Arrays.asList("123", "321")));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).sdiff("key1", "key2");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -308,13 +276,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.sdiff(anyString(), anyString())).thenReturn(new HashSet<String>());
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(0, redisQParser.parse());
     verify(jedisMock).sdiff("key1", "key2");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(0, terms.size());
   }
 
   @Test
@@ -339,13 +304,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.sunion(anyString(), anyString())).thenReturn(new HashSet<>(Arrays.asList("123", "321")));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).sunion("key1", "key2");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -357,13 +319,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.sunion(anyString(), anyString())).thenReturn(new HashSet<String>());
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(0, redisQParser.parse());
     verify(jedisMock).sunion("key1", "key2");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(0, terms.size());
   }
 
   @Test
@@ -382,13 +341,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.hvals(anyString())).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).hvals("simpleKey");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -398,13 +354,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.hvals(anyString())).thenReturn(new ArrayList<String>());
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(0, redisQParser.parse());
     verify(jedisMock).hvals("simpleKey");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(0, terms.size());
   }
 
   @Test
@@ -423,13 +376,11 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.hkeys(anyString())).thenReturn(new HashSet<>(Arrays.asList("123", "321")));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).hkeys("simpleKey");
     final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -439,13 +390,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.hkeys(anyString())).thenReturn(new HashSet<String>());
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(0, redisQParser.parse());
     verify(jedisMock).hkeys("simpleKey");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(0, terms.size());
   }
 
   @Test
@@ -475,13 +423,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.hget(anyString(), anyString())).thenReturn("123");
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(1, redisQParser.parse());
     verify(jedisMock).hget("simpleKey", "f1");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(1, terms.size());
   }
 
   @Test
@@ -492,13 +437,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.hget(anyString(), anyString())).thenReturn(null);
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(0, redisQParser.parse());
     verify(jedisMock).hget("simpleKey", "f1");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(0, terms.size());
   }
 
   @Test
@@ -525,13 +467,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.hmget(anyString(), anyString())).thenReturn(Arrays.asList("123"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(1, redisQParser.parse());
     verify(jedisMock).hmget("hash", "field1");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(1, terms.size());
   }
 
   @Test
@@ -543,13 +482,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.hmget(anyString(), anyString())).thenReturn(new ArrayList<String>());
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(0, redisQParser.parse());
     verify(jedisMock).hmget("hash", "field1");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(0, terms.size());
   }
 
   @Test
@@ -568,13 +504,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.get(any(byte[].class))).thenReturn("val".getBytes());
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(1, redisQParser.parse());
     verify(jedisMock).get("simpleKey".getBytes());
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(1, terms.size());
   }
 
   @Test
@@ -585,13 +518,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.get(any(byte[].class))).thenReturn("[1,2,3]".getBytes());
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(3, redisQParser.parse());
     verify(jedisMock).get("simpleKey".getBytes());
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(3, terms.size());
   }
 
   @Test
@@ -602,13 +532,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.get(any(byte[].class))).thenReturn(Compressor.compressGzip("1".getBytes()));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(1, redisQParser.parse());
     verify(jedisMock).get("simpleKey".getBytes());
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(1, terms.size());
   }
 
   @Test
@@ -621,13 +548,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.get(any(byte[].class))).thenReturn(Compressor.compressGzip("[100,200,300]".getBytes()));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(3, redisQParser.parse());
     verify(jedisMock).get("simpleKey".getBytes());
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(3, terms.size());
   }
 
   @Test
@@ -637,13 +561,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.get(anyString())).thenReturn(null);
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(0, redisQParser.parse());
     verify(jedisMock).get("simpleKey".getBytes());
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(0, terms.size());
   }
 
   @Test
@@ -653,13 +574,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.lindex(anyString(), anyLong())).thenReturn("value");
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(1, redisQParser.parse());
     verify(jedisMock).lindex("simpleKey", 0);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(1, terms.size());
   }
 
   @Test
@@ -670,13 +588,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.lindex(anyString(), anyLong())).thenReturn("value");
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(1, redisQParser.parse());
     verify(jedisMock).lindex("simpleKey", 10);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(1, terms.size());
   }
 
   @Test
@@ -687,13 +602,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.lindex(anyString(), anyLong())).thenReturn(null);
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(0, redisQParser.parse());
     verify(jedisMock).lindex("simpleKey", 10);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(0, terms.size());
   }
 
   @Test
@@ -718,13 +630,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.mget(anyString(), anyString())).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).mget("key1", "key2");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -736,13 +645,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.mget(anyString(), anyString())).thenReturn(new ArrayList<String>());
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(0, redisQParser.parse());
     verify(jedisMock).mget("key1", "key2");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(0, terms.size());
   }
 
   @Test
@@ -761,13 +667,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.lrange(anyString(), anyLong(), anyLong())).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).lrange("simpleKey", 0, -1);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -778,13 +681,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.lrange(anyString(), anyLong(), anyLong())).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).lrange("simpleKey", -1, -1);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -795,13 +695,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.lrange(anyString(), anyLong(), anyLong())).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).lrange("simpleKey", 0, 1);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -813,13 +710,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.lrange(anyString(), anyLong(), anyLong())).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).lrange("simpleKey", 2, 3);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -832,13 +726,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.lrange(anyString(), anyLong(), anyLong())).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).lrange("simpleKey", 0, -1);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -851,13 +742,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.lrange(anyString(), anyLong(), anyLong())).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).lrange("simpleKey", 0, -1);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -869,13 +757,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.lrange(anyString(), anyLong(), anyLong())).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).lrange("simpleKey", 0, -1);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -885,13 +770,10 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.lrange(anyString(), anyLong(), anyLong())).thenReturn(new ArrayList<String>());
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(0, redisQParser.parse());
     verify(jedisMock).lrange("simpleKey", 0, -1);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(0, terms.size());
   }
 
   @Test
@@ -901,15 +783,12 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.sort(anyString(), any(SortingParams.class))).thenReturn(new ArrayList<String>());
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(0, redisQParser.parse());
     final ArgumentCaptor<SortingParams> argument = ArgumentCaptor.forClass(SortingParams.class);
     verify(jedisMock).sort(eq("simpleKey"), argument.capture());
     Assert.assertEquals(getSortingParamString(new SortingParams()), getSortingParamString(argument.getValue()));
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(0, terms.size());
   }
 
   @Test
@@ -919,15 +798,12 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.sort(anyString(), any(SortingParams.class))).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     final ArgumentCaptor<SortingParams> argument = ArgumentCaptor.forClass(SortingParams.class);
     verify(jedisMock).sort(eq("simpleKey"), argument.capture());
     Assert.assertEquals(getSortingParamString(new SortingParams()), getSortingParamString(argument.getValue()));
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -938,15 +814,12 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.sort(anyString(), any(SortingParams.class))).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     final ArgumentCaptor<SortingParams> argument = ArgumentCaptor.forClass(SortingParams.class);
     verify(jedisMock).sort(eq("simpleKey"), argument.capture());
     Assert.assertEquals(getSortingParamString(new SortingParams().alpha()), getSortingParamString(argument.getValue()));
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -957,15 +830,12 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.sort(anyString(), any(SortingParams.class))).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     final ArgumentCaptor<SortingParams> argument = ArgumentCaptor.forClass(SortingParams.class);
     verify(jedisMock).sort(eq("simpleKey"), argument.capture());
     Assert.assertEquals(getSortingParamString(new SortingParams().asc()), getSortingParamString(argument.getValue()));
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -976,15 +846,12 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.sort(anyString(), any(SortingParams.class))).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     final ArgumentCaptor<SortingParams> argument = ArgumentCaptor.forClass(SortingParams.class);
     verify(jedisMock).sort(eq("simpleKey"), argument.capture());
     Assert.assertEquals(getSortingParamString(new SortingParams().desc()), getSortingParamString(argument.getValue()));
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -995,16 +862,13 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.sort(anyString(), any(SortingParams.class))).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     final ArgumentCaptor<SortingParams> argument = ArgumentCaptor.forClass(SortingParams.class);
     verify(jedisMock).sort(eq("simpleKey"), argument.capture());
     Assert.assertEquals(getSortingParamString(new SortingParams().limit(0, 100)),
         getSortingParamString(argument.getValue()));
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -1015,16 +879,13 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.sort(anyString(), any(SortingParams.class))).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     final ArgumentCaptor<SortingParams> argument = ArgumentCaptor.forClass(SortingParams.class);
     verify(jedisMock).sort(eq("simpleKey"), argument.capture());
     Assert.assertEquals(getSortingParamString(new SortingParams().limit(100, 0)),
         getSortingParamString(argument.getValue()));
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -1036,16 +897,13 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.sort(anyString(), any(SortingParams.class))).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     final ArgumentCaptor<SortingParams> argument = ArgumentCaptor.forClass(SortingParams.class);
     verify(jedisMock).sort(eq("simpleKey"), argument.capture());
     Assert.assertEquals(getSortingParamString(new SortingParams().limit(100, 1000)),
         getSortingParamString(argument.getValue()));
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -1056,16 +914,13 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.sort(anyString(), any(SortingParams.class))).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     final ArgumentCaptor<SortingParams> argument = ArgumentCaptor.forClass(SortingParams.class);
     verify(jedisMock).sort(eq("simpleKey"), argument.capture());
     Assert.assertEquals(getSortingParamString(new SortingParams().by("foo_*")),
         getSortingParamString(argument.getValue()));
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -1077,16 +932,13 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.sort(anyString(), any(SortingParams.class))).thenReturn(Arrays.asList("123", "321"));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     final ArgumentCaptor<SortingParams> argument = ArgumentCaptor.forClass(SortingParams.class);
     verify(jedisMock).sort(eq("simpleKey"), argument.capture());
     Assert.assertEquals(getSortingParamString(new SortingParams().get("get_*")),
         getSortingParamString(argument.getValue()));
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -1097,13 +949,10 @@ public class TestRedisQParser {
     when(jedisMock.zrevrangeWithScores(anyString(), anyLong(), anyLong()))
         .thenReturn(new HashSet<>(Arrays.asList(new Tuple("123", (double) 1.0f), new Tuple("321", (double) 1.0f))));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).zrevrangeWithScores("simpleKey", 0, -1);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -1116,13 +965,10 @@ public class TestRedisQParser {
     when(jedisMock.zrevrangeWithScores(anyString(), anyLong(), anyLong()))
         .thenReturn(new HashSet<>(Arrays.asList(new Tuple("123", (double) 1.0f), new Tuple("321", (double) 1.0f))));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).zrevrangeWithScores("simpleKey", 1, 100);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -1133,13 +979,10 @@ public class TestRedisQParser {
     when(jedisMock.zrangeWithScores(anyString(), anyLong(), anyLong()))
         .thenReturn(new HashSet<>(Arrays.asList(new Tuple("123", (double) 1.0f), new Tuple("321", (double) 1.0f))));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).zrangeWithScores("simpleKey", 0, -1);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -1152,13 +995,10 @@ public class TestRedisQParser {
     when(jedisMock.zrangeWithScores(anyString(), anyLong(), anyLong()))
         .thenReturn(new HashSet<>(Arrays.asList(new Tuple("123", (double) 1.0f), new Tuple("321", (double) 1.0f))));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).zrangeWithScores("simpleKey", 1, 100);
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -1169,13 +1009,10 @@ public class TestRedisQParser {
     when(jedisMock.zrevrangeByScoreWithScores(anyString(), anyString(), anyString()))
         .thenReturn(new HashSet<>(Arrays.asList(new Tuple("123", (double) 1.0f), new Tuple("321", (double) 1.0f))));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).zrevrangeByScoreWithScores("simpleKey", "+inf", "-inf");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
     @Test
@@ -1186,15 +1023,12 @@ public class TestRedisQParser {
     when(localParamsMock.get("max")).thenReturn("100");
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.zrevrangeByScoreWithScores(anyString(), anyString(), anyString()))
-        .thenReturn(new HashSet<>(Arrays.asList(new Tuple("123", (double) 1.0f), new Tuple("321", (double) 1.0f))));
+      .thenReturn(new HashSet<>(Arrays.asList(new Tuple("123", (double) 1.0f), new Tuple("321", (double) 1.0f))));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).zrevrangeByScoreWithScores("simpleKey", "100", "1");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -1205,13 +1039,10 @@ public class TestRedisQParser {
     when(jedisMock.zrangeByScoreWithScores(anyString(), anyString(), anyString()))
         .thenReturn(new HashSet<>(Arrays.asList(new Tuple("123", (double) 1.0f), new Tuple("321", (double) 1.0f))));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).zrangeByScoreWithScores("simpleKey", "-inf", "+inf");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -1224,13 +1055,10 @@ public class TestRedisQParser {
     when(jedisMock.zrangeByScoreWithScores(anyString(), anyString(), anyString()))
         .thenReturn(new HashSet<>(Arrays.asList(new Tuple("123", (double) 1.0f), new Tuple("321", (double) 1.0f))));
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).zrangeByScoreWithScores("simpleKey", "1", "100");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -1248,13 +1076,10 @@ public class TestRedisQParser {
     when(jedisMock.eval(anyString(), anyInt(), (String) anyVararg())).thenReturn(1);
 
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(1, redisQParser.parse());
     verify(jedisMock).eval("return 1;", 1, "k", "a");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(1, terms.size());
   }
 
   @Test
@@ -1265,11 +1090,8 @@ public class TestRedisQParser {
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(jedisMock.smembers(anyString())).thenReturn(new HashSet<>(Arrays.asList("123 124", "321")));
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(2, redisQParser.parse());
     verify(jedisMock).smembers("simpleKey");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(2, terms.size());
   }
 
   @Test
@@ -1279,14 +1101,11 @@ public class TestRedisQParser {
     when(localParamsMock.getBool("useAnalyzer", false)).thenReturn(true);
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new WhitespaceAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new WhitespaceAnalyzer());
     when(jedisMock.smembers(anyString())).thenReturn(new HashSet<>(Arrays.asList("123 124", "321")));
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, commandHandler);
-    final Query query = redisQParser.parse();
+    assertTermSize(3, redisQParser.parse());
     verify(jedisMock).smembers("simpleKey");
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(3, terms.size());
   }
 
   @Test
@@ -1297,15 +1116,12 @@ public class TestRedisQParser {
     when(localParamsMock.get("retries")).thenReturn("2");
     when(localParamsMock.get(QueryParsing.V)).thenReturn("string_field");
     when(requestMock.getSchema()).thenReturn(schema);
-    when(schema.getQueryAnalyzer()).thenReturn(new WhitespaceAnalyzer(Version.LUCENE_48));
+    when(schema.getQueryAnalyzer()).thenReturn(new WhitespaceAnalyzer());
     when(jedisPoolMock.getResource()).thenReturn(jedisFailingMock).thenReturn(jedisMock);
     when(jedisFailingMock.smembers("simpleKey")).thenThrow(new JedisException("Synthetic exception"));
     when(jedisMock.smembers("simpleKey")).thenReturn(new HashSet<String>(Collections.singletonList("value")));
     redisQParser = new RedisQParser("string_field", localParamsMock, paramsMock, requestMock, new RetryingCommandHandler(jedisPoolMock, 1));
-    final Query query = redisQParser.parse();
-    final Set<Term> terms = new HashSet<>();
-    query.extractTerms(terms);
-    Assert.assertEquals(1, terms.size());
+    assertTermSize(1, redisQParser.parse());
   }
 
   private static String getSortingParamString(final SortingParams params) {
@@ -1316,6 +1132,11 @@ public class TestRedisQParser {
     }
 
     return builder.toString().trim();
+  }
+
+  private static void assertTermSize(final int size, final Query query) {
+    final BooleanQuery booleanQuery = (BooleanQuery) query;
+    Assert.assertEquals(size, booleanQuery.clauses().size());
   }
 }
 


### PR DESCRIPTION
These are the necessary changes to upgrade to Solr 5.3. Most notably:

 - `ConstantScoreQuery.getQuery()` now returns the `Filter` object and no longer `null`, so I added the instance of check, but I am not sure about it (see `ConstantScoreQueryExtractor`)
 - `TestTaggedQueryHighlighterIT#testConstantScoreQueryWithFilterPartOnly()` fails with a NP exception with the following trace:
```
java.lang.RuntimeException: Exception during query
	at org.apache.lucene.util.BytesRef.deepCopyOf(BytesRef.java:281)
	at org.apache.lucene.analysis.tokenattributes.BytesTermAttributeImpl.copyTo(BytesTermAttributeImpl.java:51)
	at org.apache.lucene.analysis.tokenattributes.BytesTermAttributeImpl.clone(BytesTermAttributeImpl.java:57)
	at org.apache.lucene.util.AttributeSource$State.clone(AttributeSource.java:54)
	at org.apache.lucene.util.AttributeSource.captureState(AttributeSource.java:281)
	at org.apache.lucene.analysis.CachingTokenFilter.fillCache(CachingTokenFilter.java:96)
	at org.apache.lucene.analysis.CachingTokenFilter.incrementToken(CachingTokenFilter.java:70)
	at org.apache.lucene.index.memory.MemoryIndex.addField(MemoryIndex.java:458)
	at org.apache.lucene.index.memory.MemoryIndex.addField(MemoryIndex.java:390)
	at org.apache.lucene.index.memory.MemoryIndex.addField(MemoryIndex.java:365)
	at org.apache.lucene.index.memory.MemoryIndex.addField(MemoryIndex.java:345)
	at org.apache.lucene.search.highlight.WeightedSpanTermExtractor.getLeafContext(WeightedSpanTermExtractor.java:396)
	at org.apache.lucene.search.highlight.WeightedSpanTermExtractor.extract(WeightedSpanTermExtractor.java:235)
	at org.apache.lucene.search.highlight.WeightedSpanTermExtractor.extract(WeightedSpanTermExtractor.java:158)
	at org.apache.lucene.search.highlight.WeightedSpanTermExtractor.getWeightedSpanTerms(WeightedSpanTermExtractor.java:518)
	at org.apache.lucene.search.highlight.QueryScorer.initExtractor(QueryScorer.java:219)
	at org.apache.lucene.search.highlight.QueryScorer.init(QueryScorer.java:187)
	at org.apache.lucene.search.highlight.Highlighter.getBestTextFragments(Highlighter.java:196)
	at org.apache.solr.highlight.DefaultSolrHighlighter.doHighlightingByHighlighter(DefaultSolrHighlighter.java:594)
	at org.apache.solr.highlight.DefaultSolrHighlighter.doHighlighting(DefaultSolrHighlighter.java:428)
	at com.sematext.solr.highlighter.TaggedQueryHighlighter.doHighlighting(TaggedQueryHighlighter.java:77)
	at org.apache.solr.handler.component.HighlightComponent.process(HighlightComponent.java:143)
	at org.apache.solr.handler.component.SearchHandler.handleRequestBody(SearchHandler.java:277)
	at org.apache.solr.handler.RequestHandlerBase.handleRequest(RequestHandlerBase.java:143)
	at org.apache.solr.core.SolrCore.execute(SolrCore.java:2068)
	at org.apache.solr.util.TestHarness.query(TestHarness.java:320)
	at org.apache.solr.util.TestHarness.query(TestHarness.java:302)
	at org.apache.solr.SolrTestCaseJ4.assertQ(SolrTestCaseJ4.java:739)
	at org.apache.solr.SolrTestCaseJ4.assertQ(SolrTestCaseJ4.java:732)
	at com.sematext.solr.highlighter.TestTaggedQueryHighlighterIT.testConstantScoreQueryWithFilterPartOnly(TestTaggedQueryHighlighterIT.java:178)
```

There I have no idea what that could be.