### PR TITLE
Solr 6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <solr.version>6.0.0</solr.version>
+        <solr.version>6.1.0</solr.version>
         <junit.version>4.12</junit.version>
         <gson.version>2.5</gson.version>
         <mockito.version>1.10.19</mockito.version>

--- a/src/main/java/com/sematext/solr/redis/RedisQParser.java
+++ b/src/main/java/com/sematext/solr/redis/RedisQParser.java
@@ -209,14 +209,14 @@ final class RedisQParser extends QParser {
     if (shouldUseTermsQuery) {
       final List<BytesRef> terms = new ArrayList<>(queryTerms.size());
       for (Pair<BytesRef, Float> pair : queryTerms) {
-        terms.add(pair.getKey());
+        terms.add(pair.first());
       }
       termsQuery = new TermsQuery(fieldName, terms);
     } else {
       final BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
       booleanQueryBuilder.setDisableCoord(true);
       for (Pair<BytesRef, Float> pair : queryTerms) {
-        addTermToQuery(booleanQueryBuilder, fieldName, pair.getKey(), pair.getValue());
+        addTermToQuery(booleanQueryBuilder, fieldName, pair.first(), pair.second());
       }
       termsQuery = booleanQueryBuilder.build();
     }


### PR DESCRIPTION
```Pair.getKey()``` and ```Pair.getValue()``` where renamed to ```Pair.first()``` and ```Pair.second()``` in Solr 6.1 as mentioned here: [https://issues.apache.org/jira/browse/SOLR-9071](https://issues.apache.org/jira/browse/SOLR-9071)

apart from that it seems to run fine in our tests. 