### PR TITLE
upgraded to Solr 8.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
   - cat /etc/hosts # optionally check the content *after*
 jdk:
-  - oraclejdk8
+  - openjdk11
 cache:
   directories:
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: java
 dist: focal
 script: "mvn test verify -Dskip.integration.tests=false"
 before_install:
+  - sudo apt-get update
+  - sudo apt-get -y install openjdk-11-jdk
   - cat /etc/hosts # optionally check the content *before*
   - sudo hostname "$(hostname | cut -c1-63)"
   - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 language: java
-# shouldn't be needed because Maven stats its own Redis
-#services:
-#  - redis-server
+dist: focal
 script: "mvn test verify -Dskip.integration.tests=false"
 before_install:
   - cat /etc/hosts # optionally check the content *before*
   - sudo hostname "$(hostname | cut -c1-63)"
   - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
   - cat /etc/hosts # optionally check the content *after*
-env:
-  matrix:
-    - TRAVIS_JDK=adopt@1.11.0-7
 cache:
   directories:
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: java
-services:
-  - redis-server
+# shouldn't be needed because Maven stats its own Redis
+#services:
+#  - redis-server
 script: "mvn test verify -Dskip.integration.tests=false"
 before_install:
   - cat /etc/hosts # optionally check the content *before*
   - sudo hostname "$(hostname | cut -c1-63)"
   - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
   - cat /etc/hosts # optionally check the content *after*
-jdk:
-  - openjdk11
+env:
+  matrix:
+    - TRAVIS_JDK=adopt@1.11.0-7
 cache:
   directories:
     - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -102,9 +102,14 @@
 
     <dependencies>
         <dependency>
+		  <groupId>it.ozimov</groupId>
+		  <artifactId>embedded-redis</artifactId>
+		  <version>0.7.3</version>
+		</dependency>
+        <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>2.7.3</version>
+            <version>2.10.2</version>
         </dependency>
 
         <dependency>
@@ -279,31 +284,6 @@
                 <configuration>
                     <skipTests>${skip.integration.tests}</skipTests>
                 </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>ru.trylogic.maven.plugins</groupId>
-                <artifactId>redis-maven-plugin</artifactId>
-                <version>1.4.5</version>
-                <configuration>
-                    <forked>true</forked>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>start-redis</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>stop-redis</id>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>shutdown</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sematext</groupId>
     <artifactId>solr-redis</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Solr Redis </name>
     <description>Solr Redis plugin</description>
@@ -91,7 +91,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <solr.version>6.2.0</solr.version>
+        <solr.version>8.6.0</solr.version>
         <junit.version>4.12</junit.version>
         <gson.version>2.5</gson.version>
         <mockito.version>1.10.19</mockito.version>
@@ -188,15 +188,15 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -209,6 +209,7 @@
 
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -222,7 +223,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>1.5</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/src/main/java/com/sematext/lucene/query/extractor/QueryExtractor.java
+++ b/src/main/java/com/sematext/lucene/query/extractor/QueryExtractor.java
@@ -9,7 +9,7 @@ import org.apache.lucene.search.Query;
  * This abstract class is template for classes which extends org.apache.lucene.search.Query.
  *
  * @author prog
- * @param <T>
+ * @param <T> Query type.
  */
 public abstract class QueryExtractor<T extends Query> {
 

--- a/src/main/java/com/sematext/solr/redis/RedisQParser.java
+++ b/src/main/java/com/sematext/solr/redis/RedisQParser.java
@@ -27,10 +27,10 @@ import com.sematext.solr.redis.command.ZRevrangeByScore;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.queries.TermsQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.solr.common.params.SolrParams;
@@ -217,10 +217,9 @@ final class RedisQParser extends QParser {
       for (Pair<BytesRef, Float> pair : queryTerms) {
         terms.add(pair.first());
       }
-      termsQuery = new TermsQuery(fieldName, terms);
+      termsQuery = new TermInSetQuery(fieldName, terms);
     } else {
       final BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
-      booleanQueryBuilder.setDisableCoord(true);
       for (Pair<BytesRef, Float> pair : queryTerms) {
         addTermToQuery(booleanQueryBuilder, fieldName, pair.first(), pair.second());
       }
@@ -248,8 +247,7 @@ final class RedisQParser extends QParser {
   private void addTermToQuery(final BooleanQuery.Builder queryBuilder, final String fieldName, final BytesRef term,
       final Float score) {
     Query termQuery = new TermQuery(new Term(fieldName, term));
-
-    if (!score.isNaN()) {
+    if (!score.isNaN() && (score > 0)) {
       termQuery = new BoostQuery(termQuery, score);
     }
 

--- a/src/main/java/com/sematext/solr/redis/RedisQParserPlugin.java
+++ b/src/main/java/com/sematext/solr/redis/RedisQParserPlugin.java
@@ -89,7 +89,7 @@ public class RedisQParserPlugin extends QParserPlugin {
     final GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
     poolConfig.setMaxTotal(getInt(args, MAX_CONNECTIONS_FIELD, DEFAULT_MAX_CONNECTIONS));
 
-    final String host = getString(args, HOST_FIELD, HostAndPort.LOCALHOST_STR);
+    final String host = getString(args, HOST_FIELD, HostAndPort.getLocalhost());
     final int timeout = getInt(args, TIMEOUT_FIELD, Protocol.DEFAULT_TIMEOUT);
     final String password = getString(args, PASSWORD_FIELD, null);
     final int database = getInt(args, DATABASE_FIELD, Protocol.DEFAULT_DATABASE);

--- a/src/test/java/com/sematext/solr/highlighter/TestTaggedQueryHighlighterIT.java
+++ b/src/test/java/com/sematext/solr/highlighter/TestTaggedQueryHighlighterIT.java
@@ -30,9 +30,9 @@ public class TestTaggedQueryHighlighterIT extends SolrTestCaseJ4 {
     assertTrue("wrong highlighter: " + highlighter.getClass(), highlighter instanceof TaggedQueryHighlighter);
     
     redisServer = RedisServer.builder()
-    		.port(6379)
-    		.setting("bind localhost")
-    		.build();
+        .port(6379)
+        .setting("bind localhost")
+        .build();
     redisServer.start();
   }
 
@@ -189,8 +189,7 @@ public class TestTaggedQueryHighlighterIT extends SolrTestCaseJ4 {
   }
   
   @AfterClass
-  public static void afterClass()	
-  {	
+  public static void afterClass() { 
     redisServer.stop();
-  }	
+  } 
 }

--- a/src/test/java/com/sematext/solr/highlighter/TestTaggedQueryHighlighterIT.java
+++ b/src/test/java/com/sematext/solr/highlighter/TestTaggedQueryHighlighterIT.java
@@ -7,9 +7,11 @@ import static org.apache.solr.SolrTestCaseJ4.commit;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.handler.component.HighlightComponent;
 import org.apache.solr.highlight.SolrHighlighter;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
+import redis.embedded.RedisServer;
 
 /**
  *
@@ -18,12 +20,20 @@ import redis.clients.jedis.Jedis;
 public class TestTaggedQueryHighlighterIT extends SolrTestCaseJ4 {
   
   private Jedis jedis;
+  
+  private static RedisServer redisServer;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     initCore("tagged-highlighting-solrconfig.xml", "schema.xml");
     SolrHighlighter highlighter = HighlightComponent.getHighlighter(h.getCore());
     assertTrue("wrong highlighter: " + highlighter.getClass(), highlighter instanceof TaggedQueryHighlighter);
+    
+    redisServer = RedisServer.builder()
+    		.port(6379)
+    		.setting("bind localhost")
+    		.build();
+    redisServer.start();
   }
 
   @Override
@@ -177,4 +187,10 @@ public class TestTaggedQueryHighlighterIT extends SolrTestCaseJ4 {
     params.add("hl.fl", "location");
     assertQ(req(params), "*[count(//doc)=1]", "count(//lst[@name='highlighting']/*)=1");
   }
+  
+  @AfterClass
+  public static void afterClass()	
+  {	
+    redisServer.stop();
+  }	
 }

--- a/src/test/java/com/sematext/solr/redis/TestRedisQParser.java
+++ b/src/test/java/com/sematext/solr/redis/TestRedisQParser.java
@@ -4,6 +4,8 @@ import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.TermInSetQuery;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.schema.IndexSchema;
@@ -26,7 +28,6 @@ import java.io.IOException;
 import java.util.*;
 import java.util.zip.GZIPOutputStream;
 import org.apache.lucene.index.MultiReader;
-import org.apache.lucene.queries.TermsQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.IndexSearcher;
 import static org.junit.Assert.assertTrue;
@@ -1328,7 +1329,7 @@ public class TestRedisQParser {
     verify(jedisMock).smembers("simpleKey");
     IndexSearcher searcher = new IndexSearcher(new MultiReader());
     Query rewrittenQuery = searcher.rewrite(query);
-    assertTrue(rewrittenQuery instanceof TermsQuery);
+    assertTrue(rewrittenQuery instanceof TermInSetQuery);
   }
 
 
@@ -1349,7 +1350,7 @@ public class TestRedisQParser {
       ConstantScoreQuery constantScoreQuery = (ConstantScoreQuery)rewrittenQuery;
       rewrittenQuery = constantScoreQuery.getQuery();
     }
-    searcher.createNormalizedWeight(rewrittenQuery, true).extractTerms(terms);
+    rewrittenQuery.visit(QueryVisitor.termCollector(terms));
     return terms;
   }
 }

--- a/src/test/java/com/sematext/solr/redis/TestRedisQParserPlugin.java
+++ b/src/test/java/com/sematext/solr/redis/TestRedisQParserPlugin.java
@@ -45,7 +45,7 @@ public class TestRedisQParserPlugin {
   public void shouldConfigurePoolWithDefaultParametersIfNoSpecificConfigurationIsGiven() {
     parserPlugin.init(new NamedList());
 
-    verify(parserPlugin).createPool(poolConfigArgument.capture(), eq(HostAndPort.LOCALHOST_STR),
+    verify(parserPlugin).createPool(poolConfigArgument.capture(), eq(HostAndPort.getLocalhost()),
         eq(Protocol.DEFAULT_PORT), eq(Protocol.DEFAULT_TIMEOUT), passwordArgument.capture(),
         eq(Protocol.DEFAULT_DATABASE));
     assertNull(passwordArgument.getValue());
@@ -56,7 +56,7 @@ public class TestRedisQParserPlugin {
   public void shouldConfigurePoolWithDefaultParametersIfNullIsGiven() {
     parserPlugin.init(null);
 
-    verify(parserPlugin).createPool(poolConfigArgument.capture(), eq(HostAndPort.LOCALHOST_STR),
+    verify(parserPlugin).createPool(poolConfigArgument.capture(), eq(HostAndPort.getLocalhost()),
         eq(Protocol.DEFAULT_PORT), eq(Protocol.DEFAULT_TIMEOUT), passwordArgument.capture(),
         eq(Protocol.DEFAULT_DATABASE));
     assertNull(passwordArgument.getValue());
@@ -97,7 +97,7 @@ public class TestRedisQParserPlugin {
     list.add("password", "s3cr3t");
     parserPlugin.init(list);
 
-    verify(parserPlugin).createPool(poolConfigArgument.capture(), eq(HostAndPort.LOCALHOST_STR),
+    verify(parserPlugin).createPool(poolConfigArgument.capture(), eq(HostAndPort.getLocalhost()),
         eq(Protocol.DEFAULT_PORT), eq(Protocol.DEFAULT_TIMEOUT), eq("s3cr3t"),
         eq(Protocol.DEFAULT_DATABASE));
     verify(parserPlugin).createCommandHandler(poolArgument.capture(), eq(1));
@@ -110,7 +110,7 @@ public class TestRedisQParserPlugin {
     list.add("database", "1");
     parserPlugin.init(list);
 
-    verify(parserPlugin).createPool(poolConfigArgument.capture(), eq(HostAndPort.LOCALHOST_STR),
+    verify(parserPlugin).createPool(poolConfigArgument.capture(), eq(HostAndPort.getLocalhost()),
         eq(Protocol.DEFAULT_PORT), eq(Protocol.DEFAULT_TIMEOUT), passwordArgument.capture(),
         eq(1));
     verify(parserPlugin).createCommandHandler(poolArgument.capture(), eq(1));
@@ -125,7 +125,7 @@ public class TestRedisQParserPlugin {
     list.add("timeout", "100");
     parserPlugin.init(list);
 
-    verify(parserPlugin).createPool(poolConfigArgument.capture(), eq(HostAndPort.LOCALHOST_STR),
+    verify(parserPlugin).createPool(poolConfigArgument.capture(), eq(HostAndPort.getLocalhost()),
         eq(Protocol.DEFAULT_PORT), eq(100), passwordArgument.capture(),
         eq(Protocol.DEFAULT_DATABASE));
     verify(parserPlugin).createCommandHandler(poolArgument.capture(), eq(1));
@@ -140,7 +140,7 @@ public class TestRedisQParserPlugin {
     list.add("retries", "100");
     parserPlugin.init(list);
 
-    verify(parserPlugin).createPool(poolConfigArgument.capture(), eq(HostAndPort.LOCALHOST_STR),
+    verify(parserPlugin).createPool(poolConfigArgument.capture(), eq(HostAndPort.getLocalhost()),
         eq(Protocol.DEFAULT_PORT), eq(Protocol.DEFAULT_TIMEOUT), passwordArgument.capture(),
         eq(Protocol.DEFAULT_DATABASE));
     verify(parserPlugin).createCommandHandler(poolArgument.capture(), eq(100));
@@ -155,7 +155,7 @@ public class TestRedisQParserPlugin {
     list.add("maxConnections", "100");
     parserPlugin.init(list);
 
-    verify(parserPlugin).createPool(poolConfigArgument.capture(), eq(HostAndPort.LOCALHOST_STR),
+    verify(parserPlugin).createPool(poolConfigArgument.capture(), eq(HostAndPort.getLocalhost()),
         eq(Protocol.DEFAULT_PORT), eq(Protocol.DEFAULT_TIMEOUT), passwordArgument.capture(),
         eq(Protocol.DEFAULT_DATABASE));
     verify(parserPlugin).createCommandHandler(poolArgument.capture(), eq(1));

--- a/src/test/java/com/sematext/solr/redis/TestRedisQParserPluginIT.java
+++ b/src/test/java/com/sematext/solr/redis/TestRedisQParserPluginIT.java
@@ -31,9 +31,9 @@ public class TestRedisQParserPluginIT extends SolrTestCaseJ4 {
     initCore("solrconfig.xml", "schema.xml");
 
     redisServer = RedisServer.builder()
-    		.port(6379)
-    		.setting("bind localhost")
-    		.build();
+        .port(6379)
+        .setting("bind localhost")
+        .build();
     redisServer.start();
   }
 
@@ -1326,9 +1326,8 @@ public class TestRedisQParserPluginIT extends SolrTestCaseJ4 {
   }
   
   @AfterClass
-  public static void afterClass()	
-  {	
+  public static void afterClass() { 
     redisServer.stop();
-  }	
+  } 
 }
 

--- a/src/test/java/com/sematext/solr/redis/TestRedisQParserPluginIT.java
+++ b/src/test/java/com/sematext/solr/redis/TestRedisQParserPluginIT.java
@@ -7,10 +7,13 @@ import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
+import redis.embedded.RedisServer;
+
 import java.net.URLDecoder;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
@@ -18,12 +21,20 @@ import org.slf4j.LoggerFactory;
 
 public class TestRedisQParserPluginIT extends SolrTestCaseJ4 {
   private static final Logger log = LoggerFactory.getLogger(TestRedisQParserPluginIT.class);
-
+  
   private Jedis jedis;
+  
+  private static RedisServer redisServer;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     initCore("solrconfig.xml", "schema.xml");
+
+    redisServer = RedisServer.builder()
+    		.port(6379)
+    		.setting("bind localhost")
+    		.build();
+    redisServer.start();
   }
 
   @Before
@@ -40,7 +51,7 @@ public class TestRedisQParserPluginIT extends SolrTestCaseJ4 {
       jedis.hset("test_hash", "key1", "value1");
       jedis.lpush("test_list", "element1");
     } catch (final RuntimeException ex) {
-      log.error("Errorw when configuring local Jedis connection", ex);
+      log.error("Error when configuring local Jedis connection", ex);
     }
   }
 
@@ -1313,5 +1324,11 @@ public class TestRedisQParserPluginIT extends SolrTestCaseJ4 {
     } catch (final RuntimeException ignored) {
     }
   }
+  
+  @AfterClass
+  public static void afterClass()	
+  {	
+    redisServer.stop();
+  }	
 }
 

--- a/src/test/resources/solr/collection1/conf/schema.xml
+++ b/src/test/resources/solr/collection1/conf/schema.xml
@@ -51,7 +51,4 @@
    -->
   <uniqueKey>id</uniqueKey>
 
-  <!-- field for the QueryParser to use when an explicit fieldname is absent -->
-  <defaultSearchField>string_field</defaultSearchField>
-
 </schema>


### PR DESCRIPTION
Adding a PR with the initial commit. It might need more work. Main changes:

- TermsQuery is replaced with TermInSetQuery
- we treat boosts <=0 as Term queries
- upgraded some dependencies (e.g. maven-shade) and using Java 11